### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,6 +13,8 @@ on:
     branches: [ "main" ]
 jobs:
   run-lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/4](https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/4)

To fix the problem, we should add a `permissions` block for the job or at the root of the workflow. Since this workflow simply checks out code and runs `super-linter`, the minimal necessary permissions are `contents: read`. If the linter is configured to post comments to pull requests or issues, you may need to add `pull-requests: write` and/or `issues: write`, but the GitHub recommended starting point is always `contents: read`. The recommended fix is to add a `permissions:` block directly under the job definition (`run-lint:`) at line 15 (before `runs-on:`), specifying `contents: read`. Alternatively, you could add the permissions at the workflow root (after `name:`) if more jobs would be added later and they should inherit these permissions. Since only one job is present, the simplest change is to add it just under the job, as highlighted by CodeQL.

No additional imports, methods, or definitions are required; the only change is to the YAML structure in `.github/workflows/super-linter.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
