### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployMain.yml
+++ b/.github/workflows/deployMain.yml
@@ -1,4 +1,6 @@
 name: Deploy to Main
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/3](https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/3)

To address the flagged error, add a `permissions` block specifying the lowest level of access required for the job. Since the job only checks out code and deploys via FTP—and does not seem to require any write permission to the repo—set `permissions: { contents: read }` at the top level of the workflow. Ideally, this should be added just below the `name` entry (line 1), affecting all jobs in the workflow. No method changes or imports are needed; just a YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
