### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployMain.yml
+++ b/.github/workflows/deployMain.yml
@@ -1,4 +1,6 @@
 name: Deploy to Main
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/6](https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/6)

To fix the issue, we should add a `permissions:` block with the minimum required privileges. Because this workflow job only needs to check out the code (which requires `contents: read`) and does not appear to perform GitHub API write operations (e.g., updating pull requests, issues, or pushing to the repository), the least-privilege approach is to set:

```yaml
permissions:
  contents: read
```

This block can be placed at the workflow level (near the top, after the `name` and before or after the `on:` block) so that it applies to all jobs. No additional imports or other code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
