### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodeDev.js.yml
+++ b/.github/workflows/nodeDev.js.yml
@@ -1,4 +1,6 @@
 name: Node.js CI Dev
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/1](https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/1)

To address this issue, you should add a `permissions` block to the workflow file to limit the default GitHub token permissions to only what the workflow actually requires. In this workflow, the steps only involve checking out code and running local commands; no steps require write access to repository contents, pull requests, or other objects. Therefore, the minimal correct setting is to set permissions at the workflow root level to `contents: read`, which restricts the GitHub token to read-only access for repository contents. Edit the workflow YAML file `.github/workflows/nodeDev.js.yml` to insert the required `permissions:` section after the `name:` and before the `on:` key (i.e., as a root-level setting).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
