### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodeMain.js.yml
+++ b/.github/workflows/nodeMain.js.yml
@@ -1,4 +1,6 @@
 name: Node.js CI Main
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/2](https://github.com/Blackbird-UAV/BlackbirdUAV-Website/security/code-scanning/2)

The best fix is to add a `permissions` key with the minimal required access. Since all workflow steps are related to code checkout, dependency install, linting, and building, the only needed scope is read-only access to repository contents. The fix should be made by adding the line `permissions: { contents: read }` (or the YAML block equivalent) either at the workflow root (top-level, affecting all jobs), or directly under the `build` job (so it only applies to that job). For clarity and to avoid accidental permission inheritance for future jobs, the fix is applied at the workflow root—insert the block after the `name` and before the `on:` block.

No imports or helper code is required. Only a single line (or YAML block) needs to be added at the top of `.github/workflows/nodeMain.js.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
